### PR TITLE
Fix compatibility with bash

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -24,7 +24,7 @@ alias dkd="docker run -d -P"
 alias dki="docker run -i -t -P"
 
 # Stop all containers
-dstop() { docker stop $(docker ps -a -q);}
+dstop() { docker stop $(docker ps -a -q); }
 
 # Remove all containers
 drm() { docker rm $(docker ps -a -q); }
@@ -36,7 +36,7 @@ alias drmf='docker stop $(docker ps -a -q) && docker rm $(docker ps -a -q)'
 dri() { docker rmi $(docker images -q); }
 
 # Dockerfile build, e.g., $dbu tcnksm/test 
-dbu() {docker build -t=$1 .;}
+dbu() { docker build -t=$1 .; }
 
 # Show all alias related docker
-dalias() { alias | grep 'docker' | sed "s/^\([^=]*\)=\(.*\)/\1 => \2/"| sed "s/['|\']//g" | sort;}
+dalias() { alias | grep 'docker' | sed "s/^\([^=]*\)=\(.*\)/\1 => \2/"| sed "s/['|\']//g" | sort; }


### PR DESCRIPTION
Bash require space after {

-bash: /home/vagrant/.bashrc: line 153: syntax error near unexpected token `{docker'
-bash: /home/vagrant/.bashrc: line 153: `function dbu() {docker build -t=$1 .; }'

