### PR TITLE
Fix syntax error for bash

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -24,7 +24,7 @@ alias dkd="docker run -d -P"
 alias dki="docker run -i -t -P"
 
 # Stop all containers
-dstop() { docker stop $(docker ps -a -q);}
+dstop() { docker stop $(docker ps -a -q); }
 
 # Remove all containers
 drm() { docker rm $(docker ps -a -q); }
@@ -36,7 +36,7 @@ alias drmf='docker stop $(docker ps -a -q) && docker rm $(docker ps -a -q)'
 dri() { docker rmi $(docker images -q); }
 
 # Dockerfile build, e.g., $dbu tcnksm/test 
-dbu() {docker build -t=$1 .;}
+dbu() { docker build -t=$1 .; }
 
 # Show all alias related docker
-dalias() { alias | grep 'docker' | sed "s/^\([^=]*\)=\(.*\)/\1 => \2/"| sed "s/['|\']//g" | sort;}
+dalias() { alias | grep 'docker' | sed "s/^\([^=]*\)=\(.*\)/\1 => \2/"| sed "s/['|\']//g" | sort; }


### PR DESCRIPTION
Fix this error when using bash (tested with Linux Mint 17 ~ Ubuntu 14.04 trusty):

```
$ source ~/.bashrc
bash: /home/piloupy/.bashrc: line 45: syntax error near unexpected token `{docker'
bash: /home/piloupy/.bashrc: line 45: `dbu() {docker build -t=$1 .;}'
```
